### PR TITLE
Update ContentView.swift

### DIFF
--- a/iExpense/iExpense/ContentView.swift
+++ b/iExpense/iExpense/ContentView.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 struct ExpenseItem: Identifiable, Codable {
-    let id = UUID()
+    let var = UUID()
     let name: String
     let type: String
     let amount: Int


### PR DESCRIPTION
- Getting an warning "Immutable property will not be decoded because it is declared with an initial value which cannot be overwritten"

So if we make the variable var, we can get rid of the warning!